### PR TITLE
This fixes specify version of aws-sdk

### DIFF
--- a/serverspec-aws-resources.gemspec
+++ b/serverspec-aws-resources.gemspec
@@ -8,5 +8,5 @@ Gem::Specification.new do |s|
   s.email       = 'eric.kascic@stelligent.com'
   s.files       =  Dir['lib/*.rb'] + Dir['lib/resources/*.rb']
 
-  s.add_runtime_dependency 'aws-sdk', '>= 1.61.0'
+  s.add_runtime_dependency 'aws-sdk', '>= 1.61.0', '< 2.0.0'
 end


### PR DESCRIPTION
I found that it does not work with `aws-sdk 2.x`.

This is the result of the try in the `aws-sdk 2.1.14`. It was the same result even in the `aws-sdk 2.0.22`.

```
Failures:

  1) hogehoge behaves like test-aws-resources::hogehoge vpc vpc: vpc-1234 should be default tenancy
     Failure/Error: it { should be_default_tenancy }
     NameError:
       uninitialized constant Serverspec::Type::VPC::AWS
     Shared Example Group: "test-aws-resources::hogehoge" called from ./spec/role/hogehoge_spec.rb:4
     # ./vendor/bundle/ruby/2.2.0/bundler/gems/serverspec-aws-resources-ccb8a62b71d9/lib/resources/vpc_resource.rb:57:in `content'
     # ./vendor/bundle/ruby/2.2.0/bundler/gems/serverspec-aws-resources-ccb8a62b71d9/lib/resources/vpc_resource.rb:67:in `default_tenancy?'
     # ./spec/shared/test-aws-resources.rb:4:in `block (4 levels) in <top (required)>'
```
