### PR TITLE
Add additional checks to ec2_instances

### DIFF
--- a/lib/resources/ec2_instance_resource.rb
+++ b/lib/resources/ec2_instance_resource.rb
@@ -141,6 +141,20 @@ module Serverspec
         content.kernel_id == kernel_id
       end
 
+      def has_public_subnet?
+        instance_subnet = AWS::EC2.new.subnets[content.subnet_id]
+        instance_subnet.route_table.routes.each do |route|
+          if !route.internet_gateway.nil? && route.internet_gateway.exists?
+            return true
+          end
+        end
+        false
+      end
+
+      def public_ip_address
+        content.public_ip_address
+      end
+
       def to_s
         "EC2 instance: #{}"
       end


### PR DESCRIPTION
- Ability to check for public ip address
- Ability to check if a instance's subnet has a route to an internet gateway (i.e public subnet)

Example:

``` ruby
describe ec2_instance('i-12345678') do
  its(:public_ip_address) { should_not eq nil }
  it { should have_public_subnet }
end
```
