### PR TITLE
Add def for subnet_id to c2_instance resource

### DIFF
--- a/lib/resources/ec2_instance_resource.rb
+++ b/lib/resources/ec2_instance_resource.rb
@@ -155,6 +155,10 @@ module Serverspec
         content.public_ip_address
       end
 
+      def subnet_id
+        content.subnet_id
+      end
+
       def to_s
         "EC2 instance: #{}"
       end


### PR DESCRIPTION
Example:

describe ec2_instance('i-12345678') do
  its(:subnet_id) { should eq 'subnet-12345678' }
end
